### PR TITLE
fix: prevent OOB slice panic in ZmtpCommand::parse for short PING frames

### DIFF
--- a/core/src/protocol/zmtp/command.rs
+++ b/core/src/protocol/zmtp/command.rs
@@ -40,8 +40,9 @@ impl ZmtpCommand {
     let body = msg.data()?; // Get command body bytes
 
     // Check command name (first part, length-prefixed)
-    if body.starts_with(b"\x04PING") && body.len() >= 5 {
+    if body.starts_with(b"\x04PING") && body.len() >= 7 {
       // PING command format: <length=4>PING<TTL(2)><Context(0+)>
+      // Requires at least 7 bytes: 1 (len prefix) + 4 (PING) + 2 (TTL)
       // Extract context after "PING" + TTL
       let context = Bytes::copy_from_slice(&body[5 + 2..]);
       Some(ZmtpCommand::Ping(context))


### PR DESCRIPTION
The PING branch only checked body.len() >= 5 before slicing body[5+2..], which panics for 5- or 6-byte bodies. 
Raise the guard to >= 7 (1 byte length prefix + 4 bytes "PING" + 2 bytes TTL) to match the actual minimum required by the PING frame format.